### PR TITLE
Lowered track and muon pt cuts to 8 GeV

### DIFF
--- a/PhysicsTools/NanoAOD/python/generalTracks_cff.py
+++ b/PhysicsTools/NanoAOD/python/generalTracks_cff.py
@@ -3,9 +3,9 @@ from PhysicsTools.NanoAOD.common_cff import *
 
 generalTrackTable = cms.EDProducer("SimpleTrackFlatTableProducer",
     src = cms.InputTag("generalTracks"),
-    cut = cms.string("pt > 10"), # filtered already above
+    cut = cms.string("pt > 8"), # filtered already above
     name = cms.string("Track"),
-    doc  = cms.string("General tracks with pt > 10 GeV"),
+    doc  = cms.string("General tracks with pt > 8 GeV"),
     singleton = cms.bool(False), # the number of entries is variable
     extension = cms.bool(False), # this is the main table for the muons
     variables = cms.PSet(P3Vars,

--- a/PhysicsTools/NanoAOD/python/muons_cff.py
+++ b/PhysicsTools/NanoAOD/python/muons_cff.py
@@ -49,7 +49,7 @@ slimmedMuonsWithUserData = cms.EDProducer("PATMuonUserDataEmbedder",
 
 finalMuons = cms.EDFilter("PATMuonRefSelector",
     src = cms.InputTag("slimmedMuonsWithUserData"),
-    cut = cms.string("pt > 15 || (pt > 3 && (passed('CutBasedIdLoose') || passed('SoftCutBasedId') || passed('SoftMvaId') || passed('CutBasedIdGlobalHighPt') || passed('CutBasedIdTrkHighPt')))")
+    cut = cms.string("pt > 8 || (pt > 3 && (passed('CutBasedIdLoose') || passed('SoftCutBasedId') || passed('SoftMvaId') || passed('CutBasedIdGlobalHighPt') || passed('CutBasedIdTrkHighPt')))")
 )
 (run2_nanoAOD_106Xv1 & ~run2_nanoAOD_devel).toModify(finalMuons, cut = "(pt > 3 && (passed('CutBasedIdLoose') || passed('SoftCutBasedId') || passed('SoftMvaId') || passed('CutBasedIdGlobalHighPt') || passed('CutBasedIdTrkHighPt')))")
 


### PR DESCRIPTION
Lowered the pt cuts for saving tracks and muons to 8 GeV after verifying the impact on file size was minimal (~1%).